### PR TITLE
Partial port to LLVM 3.4

### DIFF
--- a/configure
+++ b/configure
@@ -2458,7 +2458,7 @@ else
   llvm_bindir="$llvm_prefix/bin"
 fi
 
-for ac_prog in llvm-config-3.3 llvm-config-3.2 llvm-config-3.1 llvm-config
+for ac_prog in llvm-config-3.4 llvm-config-3.3 llvm-config-3.2 llvm-config-3.1 llvm-config
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
 set dummy $ac_prog; ac_word=$2

--- a/configure.ac
+++ b/configure.ac
@@ -26,7 +26,7 @@ AC_ARG_WITH(llvm_bindir,
   llvm_bindir="$withval",
   llvm_bindir="$llvm_prefix/bin")dnl
 
-AC_PATH_PROGS(llvm_config, [llvm-config-3.3 llvm-config-3.2 llvm-config-3.1 llvm-config],
+AC_PATH_PROGS(llvm_config, [llvm-config-3.4 llvm-config-3.3 llvm-config-3.2 llvm-config-3.1 llvm-config],
   [AC_MSG_ERROR(could not find llvm-config in $llvm_bindir)],
   ["$llvm_bindir:$PATH"])
 

--- a/src/c++/marshal.cpp
+++ b/src/c++/marshal.cpp
@@ -724,6 +724,11 @@ static CValue* translateBasicBlock(CModule *m, const BasicBlock *bb);
 static CMeta* translateMetadata(CModule *m, const MDNode *md);
 static CMeta* translateMetadataArray(CModule *m, const MDNode *md);
 
+#if LLVM_VERSION_MINOR >= 4
+static CMeta* translateMetadata(CModule *m, const DIDescriptor *desc);
+template <class T> static CMeta* translateMetadata(CModule *m, const DIRef<T> &ref);
+#endif
+
 static void makeMetaSrcLocation(CModule *m, const DebugLoc &loc, CMeta *meta) {
   meta->u.metaLocationInfo.lineNumber = loc.getLine();
   meta->u.metaLocationInfo.columnNumber = loc.getCol();
@@ -1038,6 +1043,20 @@ static CMeta* translateMetadata(CModule *m, const MDNode *md) {
   }
   return meta;
 }
+
+#if LLVM_VERSION_MINOR >= 4
+static CMeta* translateMetadata(CModule *m, const DIDescriptor &desc) {
+  const MDNode * const md(desc);
+  return translateMetadata(m, md);
+}
+
+template <class T>
+static CMeta* translateMetadata(CModule *m, const DIRef<T> &ref) {
+  const Value * const value(ref);
+  const MDNode * const md(dyn_cast<const MDNode>(value));
+  return translateMetadata(m, md);
+}
+#endif
 
 static CMeta* translateMetadataArray(CModule *m, const MDNode *md) {
   // I expect some metadata fields to be empty (e.g., templateParams).

--- a/src/c++/marshal.cpp
+++ b/src/c++/marshal.cpp
@@ -394,7 +394,9 @@ static void disposeCMeta(CMeta *meta) {
     free(meta->u.metaSubprogramInfo.name);
     free(meta->u.metaSubprogramInfo.displayName);
     free(meta->u.metaSubprogramInfo.linkageName);
+#if LLVM_VERSION_MINOR < 4
     free(meta->u.metaSubprogramInfo.returnTypeName);
+#endif
     free(meta->u.metaSubprogramInfo.filename);
     free(meta->u.metaSubprogramInfo.directory);
     break;
@@ -837,7 +839,9 @@ static void makeMetaSubprogram(CModule *m, const MDNode *md, CMeta *meta) {
   meta->u.metaSubprogramInfo.linkageName = getCStrdup(ds.getLinkageName());
   meta->u.metaSubprogramInfo.lineNumber = ds.getLineNumber();
   meta->u.metaSubprogramInfo.type = translateMetadata(m, ds.getType());
+#if LLVM_VERSION_MINOR < 4
   meta->u.metaSubprogramInfo.returnTypeName = getCStrdup(ds.getReturnTypeName());
+#endif
   meta->u.metaSubprogramInfo.isLocalToUnit = ds.isLocalToUnit();
   meta->u.metaSubprogramInfo.isDefinition = ds.isDefinition();
   meta->u.metaSubprogramInfo.virtuality = ds.getVirtuality();

--- a/src/c++/marshal.cpp
+++ b/src/c++/marshal.cpp
@@ -954,7 +954,11 @@ static void makeMetaTemplateValueParameter(CModule *m, const MDNode *md, CMeta *
   meta->u.metaTemplateValueInfo.context = translateMetadata(m, dt.getContext());
   meta->u.metaTemplateValueInfo.name = getCStrdup(dt.getName());
   meta->u.metaTemplateValueInfo.type = translateMetadata(m, dt.getType());
+#if LLVM_VERSION_MINOR < 4
   meta->u.metaTemplateValueInfo.value = dt.getValue();
+#else
+  meta->u.metaTemplateValueInfo.value = translateValue(m, dt.getValue());
+#endif
   meta->u.metaTemplateValueInfo.filename = getCStrdup(dt.getFilename());
   meta->u.metaTemplateValueInfo.directory = getCStrdup(dt.getDirectory());
   meta->u.metaTemplateValueInfo.lineNumber = dt.getLineNumber();

--- a/src/c++/marshal.cpp
+++ b/src/c++/marshal.cpp
@@ -354,8 +354,10 @@ static CallingConvention decodeCallingConvention(CallingConv::ID cc) {
   case CallingConv::X86_ThisCall: return CC_X86_THISCALL;
   case CallingConv::PTX_Kernel: return CC_PTX_KERNEL;
   case CallingConv::PTX_Device: return CC_PTX_DEVICE;
+#if LLVM_VERSION_MINOR < 4
   case CallingConv::MBLAZE_INTR: return CC_MBLAZE_INTR;
   case CallingConv::MBLAZE_SVOL: return CC_MBLAZE_SVOL;
+#endif
   }
 
   ostringstream os;

--- a/src/c++/marshal.cpp
+++ b/src/c++/marshal.cpp
@@ -752,7 +752,9 @@ static void makeMetaDerivedType(CModule *m, const MDNode *md, CMeta *meta) {
   meta->u.metaTypeInfo.filename = getCStrdup(dt.getFilename());
 
   meta->u.metaTypeInfo.typeDerivedFrom = translateMetadata(m, dt.getTypeDerivedFrom());
+#if LLVM_VERSION_MINOR < 4
   meta->u.metaTypeInfo.originalTypeSize = dt.getOriginalTypeSize();
+#endif
 }
 
 static void makeMetaCompositeType(CModule *m, const MDNode *md, CMeta *meta) {
@@ -774,7 +776,9 @@ static void makeMetaCompositeType(CModule *m, const MDNode *md, CMeta *meta) {
   meta->u.metaTypeInfo.filename = getCStrdup(dt.getFilename());
 
   meta->u.metaTypeInfo.typeDerivedFrom = translateMetadata(m, dt.getTypeDerivedFrom());
+#if LLVM_VERSION_MINOR < 4
   meta->u.metaTypeInfo.originalTypeSize = dt.getOriginalTypeSize();
+#endif
 
   meta->u.metaTypeInfo.typeArray = translateMetadataArray(m, dt.getTypeArray());
   meta->u.metaTypeInfo.runTimeLang = dt.getRunTimeLang();

--- a/src/c++/marshal.h
+++ b/src/c++/marshal.h
@@ -157,7 +157,9 @@ typedef struct {
   // CMeta *compileUnit;
   unsigned lineNumber;
   CMeta *type;
+#if LLVM_VERSION_MINOR < 4
   char *returnTypeName;
+#endif
   int isLocalToUnit;
   int isDefinition;
   unsigned virtuality;

--- a/src/c++/marshal.h
+++ b/src/c++/marshal.h
@@ -1,3 +1,4 @@
+#include <llvm/Config/llvm-config.h>
 #include <stdint.h>
 #include "llvm-base-enums.h"
 
@@ -195,7 +196,9 @@ typedef struct {
 
   // Derived and Composite Types
   CMeta *typeDerivedFrom;
+#if LLVM_VERSION_MINOR < 4
   uint64_t originalTypeSize;
+#endif
 
   // Composite Type
   CMeta *typeArray;

--- a/src/c++/marshal.h
+++ b/src/c++/marshal.h
@@ -86,7 +86,11 @@ typedef struct {
   CMeta *context;
   char *name;
   CMeta *type;
+#if LLVM_VERSION_MINOR < 4
   uint64_t value;
+#else
+  CValue *value;
+#endif
   char *filename;
   char *directory;
   unsigned lineNumber;


### PR DESCRIPTION
These changes address _part_ of what would be needed to build this Haskell package with LLVM 3.4. I have addressed only the changes needed to C++ code; I leave the Haskell changes to those who know Haskell well. Haskell code in `llvm-base-types` will also need corresponding changes.
